### PR TITLE
[Feature] [LABS-1582]: Added Search By ParentCategory

### DIFF
--- a/botbuilder/BotApiWebhooks.md
+++ b/botbuilder/BotApiWebhooks.md
@@ -1049,7 +1049,7 @@
 | functionName | String | true     | "fetchCategories"                                   |
 | botUuid      | String | true     | botUuid that is saved in the context                |
 | query        | String | false    | Checks for categories that include the given string |
-
+| parentCategory | String | false | A parent category to get its children categories	 |
 #### Result Example
 
 ```json


### PR DESCRIPTION
This adds a parameter to the webhook fetchCategories which allows it to receive the parameter parentCategory.
If parentCategory is given, only subCategories of that parentCategory will be returned.